### PR TITLE
Overwrite body and handle uncategorized changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+pr-changes-action/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-node_modules
-pr-changes-action/node_modules

--- a/index.js
+++ b/index.js
@@ -71,8 +71,7 @@ const run = async () => {
       repo,
       pull_number: prNumber,
     });
-    const body = releasePr.body;
-    const newBody = `We are ready for QA. Shoutout to @design-team @engineering-team for all the updates!:tada:\r\n${changes}\r\n${body}\r\nPR: [#${prNumber}](https://github.com/runwayml/app/pull/${prNumber})\r\n`;
+    const newBody = `We are ready for QA. Shoutout to @design-team @engineering-team for all the updates!:tada:\r\n${changes}\r\nPR: [#${prNumber}](https://github.com/runwayml/app/pull/${prNumber})\r\n`;
 
     await octokit.rest.pulls.update({
       owner,

--- a/index.js
+++ b/index.js
@@ -31,22 +31,30 @@ const run = async () => {
           repo,
           pull_number: commitPrNumber,
         });
-        if (commitPR) {
-          const commitPRBody = commitPR.body;
-          const categoryReg = new RegExp("- \\[x\\] ").exec(commitPRBody);
-          if (categoryReg && categoryReg[0]) {
-            const endIndex = commitPRBody.indexOf("\n", categoryReg.index);
-            const category = commitPRBody.substring(
-              categoryReg.index + 6,
-              endIndex - 1
-            );
-            if (!changesByGroup[category]) {
-              changesByGroup[category] = [];
-            }
-            const text = message.substring(0, commitPrNumberReg.index - 1);
-            const link = commitPR.html_url;
-            changesByGroup[category].push(`- [${text}](${link})\r\n`);
+        if (!commitPR || !commitPR.body) continue;
+
+        const commitPRBody = commitPR.body;
+
+        // Remove text before this heading, because any checkbox can match the regex for [x]
+        const typeOfChangeHeadingIndex = commitPRBody.indexOf("Type of change");
+        if (typeOfChangeHeadingIndex === -1) continue;
+        const bodyAfterHeading = commitPRBody.substring(
+          typeOfChangeHeadingIndex
+        );
+
+        // Matches [x][X][ x][x ] followed by anything and then the end of the line
+        const categoryReg = new RegExp("(- \\[ *[xX] *\\] )(.*$)", "m").exec(
+          bodyAfterHeading
+        );
+        if (categoryReg) {
+          // The contents of the second capture group `(.*$)`
+          const category = categoryReg[2];
+          if (!changesByGroup[category]) {
+            changesByGroup[category] = [];
           }
+          const text = message.substring(0, commitPrNumberReg.index - 1);
+          const link = commitPR.html_url;
+          changesByGroup[category].push(`- [${text}](${link})\r\n`);
         }
       }
     }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const run = async () => {
     const owner = github.context.repo.owner;
     const repo = github.context.repo.repo;
 
-    const { data: commits } = await octokit.rest.pulls.listCommits({
+    const commits = await octokit.paginate(octokit.rest.pulls.listCommits, {
       owner,
       repo,
       pull_number: prNumber,

--- a/index.js
+++ b/index.js
@@ -48,10 +48,10 @@ const run = async () => {
         );
         let category = "Other";
         if (categoryReg && categoryReg[2]) {
+          // The contents of the second capture group `(.*$)`
           category = categoryReg[2];
         }
-        // The contents of the second capture group `(.*$)`
-        const category = categoryReg[2];
+
         if (!changesByGroup[category]) {
           changesByGroup[category] = [];
         }

--- a/index.js
+++ b/index.js
@@ -46,16 +46,18 @@ const run = async () => {
         const categoryReg = new RegExp("(- \\[ *[xX] *\\] )(.*$)", "m").exec(
           bodyAfterHeading
         );
-        if (categoryReg) {
-          // The contents of the second capture group `(.*$)`
-          const category = categoryReg[2];
-          if (!changesByGroup[category]) {
-            changesByGroup[category] = [];
-          }
-          const text = message.substring(0, commitPrNumberReg.index - 1);
-          const link = commitPR.html_url;
-          changesByGroup[category].push(`- [${text}](${link})\r\n`);
+        let category = "Other";
+        if (categoryReg && categoryReg[2]) {
+          category = categoryReg[2];
         }
+        // The contents of the second capture group `(.*$)`
+        const category = categoryReg[2];
+        if (!changesByGroup[category]) {
+          changesByGroup[category] = [];
+        }
+        const text = message.substring(0, commitPrNumberReg.index - 1);
+        const link = commitPR.html_url;
+        changesByGroup[category].push(`- [${text}](${link})\r\n`);
       }
     }
 


### PR DESCRIPTION
This is so that the PR body can receive new changes when they are pushed to the branch.

This also fixes a bug where if a PR did not specify a category, it would not show in the list of changes. 